### PR TITLE
fix(part_res): handle input as list and string correctly

### DIFF
--- a/VirtualHavruta/util.py
+++ b/VirtualHavruta/util.py
@@ -11,6 +11,8 @@ def create_logger(f='virtual-havruta.log', name='virtual-havruta', mb=1*1024*102
     return logger
 
 def part_res(input_res, sep=''):
+    if isinstance(input_res, list):
+        input_res = ' '.join(input_res)
     if sep:
         return input_res.partition(sep)[2].strip()
     return input_res.strip()


### PR DESCRIPTION
Updated the `part_res` function to properly handle cases where the input can be either a list of strings or a single string. The function now joins list elements into a single string before processing, ensuring correct behavior when a separator is provided. This update resolves issues encountered with the new GPT-4.0 integration.