### PR TITLE
Feat/semantic search local cluster

### DIFF
--- a/VirtualHavruta/document.py
+++ b/VirtualHavruta/document.py
@@ -1,0 +1,9 @@
+from langchain_core.documents import Document
+
+
+class ChunkDocument(Document):
+    def __eq__(self, other):
+        """Overrides the default implementation of equal check."""
+        if isinstance(other, Document):
+            return self.page_content == other.page_content and self.metadata == other.metadata
+        return False

--- a/VirtualHavruta/document.py
+++ b/VirtualHavruta/document.py
@@ -5,5 +5,8 @@ class ChunkDocument(Document):
     def __eq__(self, other):
         """Overrides the default implementation of equal check."""
         if isinstance(other, Document):
-            return self.page_content == other.page_content and self.metadata == other.metadata
+            return (
+                self.page_content == other.page_content
+                and self.metadata == other.metadata
+            )
         return False

--- a/VirtualHavruta/util.py
+++ b/VirtualHavruta/util.py
@@ -1,5 +1,6 @@
 import logging
 from logging import handlers
+from typing import Iterable
 
 def create_logger(f='virtual-havruta.log', name='virtual-havruta', mb=1*1024*1024, bk=0):
     logger = logging.getLogger(name)
@@ -16,3 +17,32 @@ def part_res(input_res, sep=''):
     if sep:
         return input_res.partition(sep)[2].strip()
     return input_res.strip()
+
+def min_max_scaling(data: Iterable, offset: float = 1e-05) -> list:
+    """
+    Perform min-max scaling on a list or numpy array of numerical data.
+
+    Parameters:
+    -----------
+        data
+            The input data to be scaled.
+        offset
+            to avoid returning zero for minimum value.
+
+    Returns:
+    --------
+        The scaled data.
+    """
+    data = list(data)
+    if not data:
+        return data
+    
+    min_val = min(data)
+    max_val = max(data)
+
+    if min_val == max_val:
+        return [0.5] * len(data)  # All values are the same, return 0.5
+
+    scaled_data = [(x - min_val + offset) / (max_val - min_val) for x in data]
+
+    return scaled_data

--- a/VirtualHavruta/util.py
+++ b/VirtualHavruta/util.py
@@ -22,7 +22,7 @@ def part_res(input_res, sep=''):
         return input_res.partition(sep)[2].strip()
     return input_res.strip()
 
-def min_max_scaling(data: Iterable, offset: float = 1e-05) -> list:
+def min_max_scaling(data: Iterable, offset: float = 1e-09) -> list:
     """
     Perform min-max scaling on a list or numpy array of numerical data.
 

--- a/VirtualHavruta/util.py
+++ b/VirtualHavruta/util.py
@@ -2,6 +2,10 @@ import logging
 from logging import handlers
 from typing import Iterable
 
+from VirtualHavruta.document import ChunkDocument
+
+from langchain_core.documents import Document
+
 def create_logger(f='virtual-havruta.log', name='virtual-havruta', mb=1*1024*1024, bk=0):
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
@@ -46,3 +50,121 @@ def min_max_scaling(data: Iterable, offset: float = 1e-05) -> list:
     scaled_data = [(x - min_val + offset) / (max_val - min_val) for x in data]
 
     return scaled_data
+
+
+def dict_to_yaml_str(input_dict: dict, indent: int = 0) -> str:
+    """
+    Convert a dictionary to a YAML-like string without using external libraries.
+
+    Parameters:
+        input_dict: The dictionary to convert.
+        indent: The current indentation level.
+
+    Returns:
+    The YAML-like string representation of the input dictionary.
+    """
+    yaml_str = ""
+    for key, value in input_dict.items():
+        padding = "  " * indent
+        if isinstance(value, dict):
+            yaml_str += f"{padding}{key}:\n{dict_to_yaml_str(value, indent + 1)}"
+        elif isinstance(value, list):
+            yaml_str += f"{padding}{key}:\n"
+            for item in value:
+                yaml_str += f"{padding}- {item}\n"
+        else:
+            yaml_str += f"{padding}{key}: {value}\n"
+    return yaml_str
+
+
+def get_node_data(node: "Node") -> dict:
+    """Given a node from the graph database, return the data of the node.
+
+    Parameters
+    ----------
+    node
+        from the graph database
+
+    Returns
+    -------
+        data of the node
+    """
+    try:
+        record = node.data()
+    except AttributeError:
+        record = node._properties
+    else:
+        assert len(record) == 1
+        record: dict = next(iter(record.values()))
+    return record
+
+
+def get_id_vectordb_format(node_id: str) -> int:
+    """Given a node id from the graph database, return the corresponding document seq_num in the vectordb.
+
+    Parameters
+    ----------
+    node_id
+        id of node
+
+    Returns
+    -------
+        seq_num of the document in the vectordb
+
+    Raises
+    ------
+    """
+    return int(node_id) + 1
+
+
+def convert_node_to_doc(node: "Node", base_url: str= "https://www.sefaria.org/") -> Document:
+    """
+    Convert a node from the graph database to a Document object.
+
+    Parameters:
+        node (Node): The node from the graph database.
+
+    Returns:
+        Document: The Document object created from the node.
+    """
+    node_data: dict = get_node_data(node)
+    metadata = {k.replace("metadata.", ""):v for k, v in node_data.items() if k.startswith("metadata.")}
+    metadata['URL'] = metadata['url']
+    del metadata['url']
+    metadata["seq_num"] = get_id_vectordb_format(node_data["id"])
+    new_reference_part = metadata["URL"].replace(base_url, "")
+    new_category = metadata["docCategory"]
+    metadata["source"] = f"Reference: {new_reference_part}. Version Title: -, Document Category: {new_category}, URL: {metadata['URL']}"
+
+    page_content = dict_to_yaml_str(node_data.get("text")) if isinstance(node_data.get("text"), dict) else node_data.get("text", "")
+    return ChunkDocument(
+        page_content=page_content,
+        metadata=metadata
+    )
+
+
+def convert_vector_db_record_to_doc(record) -> ChunkDocument:
+    assert len(record) == 1
+    record: dict = next(iter(record.values()))
+    page_content = record.pop("text", None)
+    return ChunkDocument(
+        page_content=dict_to_yaml_str(page_content)
+        if isinstance(page_content, dict)
+        else page_content,
+        metadata=record
+    )
+
+
+def get_id_graph_format(document_seq_num: int) -> str:
+    """Given a document seq_num  from the vectordb, return the  id of the corresponding node in the graph database.
+
+    Parameters
+    ----------
+    document_seq_num
+        from the vectordb document
+
+    Returns
+    -------
+        id of the document in the graph database
+    """
+    return str(document_seq_num -1)

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -608,38 +608,6 @@ class VirtualHavruta:
             nodes.extend(neighbor_nodes)
         return nodes
     
-    def get_docs_corresponding_to_nodes(self, nodes: list["Node"]) -> list[Document]:
-        """Given a list of nodes from the graph database, return the corresponding documents from the vector database.
-
-        Parameters
-        ----------
-        nodes
-            from the graph database
-
-        Returns
-        -------
-            list of documents
-        """
-        # find neighbors in vector db
-        vector_records = self.neo4j_vector.query(
-            """
-            MATCH (n)
-            WHERE n.seq_num in $ids
-            RETURN DISTINCT n
-            """,
-            params={"ids": [self.get_document_id_vector_db_format(node) for node in nodes]},
-        )
-        docs = [convert_record_to_doc(record) for record in vector_records]
-        unique_ids = set()
-        docs_filtered = []
-        for doc in docs:
-            if doc.metadata["seq_num"] not in unique_ids:
-                unique_ids.add(doc.metadata["seq_num"])
-                doc.page_content = [get_node_data(node)["text"] for node in nodes
-                                    if get_node_data(node)["metadata.url"] == doc.metadata["URL"]][0]
-                docs_filtered.append(doc)
-        return docs_filtered
-
     def query_node_by_url(self, url: str,) -> str|None:
         """Given a url, query the graph database for the node with that url.
 

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -1241,8 +1241,8 @@ class VirtualHavruta:
         self.logger.info(f"MsgID={msg_id}. [RETRIEVAL] Starting rank_chunk_candidates.")
         total_token_count = 0
         if not semantic_similarity_scores:
-            if not scripture_query:
-                raise ValueError("Either provide semantic similarity scores or scripture query.")
+            if not enriched_query:
+                raise ValueError("Either provide semantic similarity scores or enriched query.")
             semantic_similarity_scores: np.array = self.compute_semantic_similarity_documents_query(chunks, query=enriched_query)
         reference_classes, token_count = self.get_reference_class(chunks, enriched_query)
         total_token_count += token_count

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -1275,8 +1275,7 @@ class VirtualHavruta:
         """
         self.logger.info(f"MsgID={msg_id}. [RETRIEVAL] Starting get_seed_chunks for KG search.")
         total_token_count = 0
-        # seeds: list[Document] = self.retrieve_nodes_matching_linker_results(screen_res, enriched_query, msg_id, filter_mode=filter_mode)
-        seeds = None
+        seeds: list[Document] = self.retrieve_nodes_matching_linker_results(screen_res, enriched_query, msg_id, filter_mode=filter_mode)
         if seeds:
             seed_chunks: list[Document] = self.get_chunks_corresponding_to_nodes(seeds)
         else:

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -88,18 +88,6 @@ def get_node_data(node: "Node") -> dict:
     return record
 
 
-def convert_record_to_doc(record: "Node") -> Document:
-    assert len(record) == 1
-    record: dict = next(iter(record.values()))
-    page_content = record.pop("text")
-    return Document(
-        page_content=dict_to_yaml_str(page_content)
-        if isinstance(page_content, dict)
-        else page_content,
-        metadata=record
-    )
-
-
 # Main Virtual Havruta functionalities
 class VirtualHavruta:
     def __init__(self, prompts_file: str, config_file: str, logger):

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -5,9 +5,7 @@ import pandas as pd
 from datetime import datetime, timedelta
 import os
 from neo4j import GraphDatabase
-import typing
 from langchain_core.documents import Document
-import numpy as np
 # Import custom langchain modules for NLP operations and vector search
 from langchain.vectorstores.neo4j_vector import Neo4jVector
 from langchain.embeddings.openai import OpenAIEmbeddings
@@ -16,8 +14,6 @@ from langchain_community.chat_models import ChatOpenAI
 from langchain.schema import SystemMessage
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_community.callbacks import get_openai_callback
-from langchain_community.utils.math import cosine_similarity
-import traceback
 import requests
 
 def dict_to_yaml_str(input_dict: dict, indent: int = 0) -> str:

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -416,7 +416,7 @@ class VirtualHavruta:
     def query_neighbors_of_doc(self, document: Document) -> list[Document]:
         query_parameters = {"url": document.metadata["URL"], "id": self.get_document_id_graph_format(document),}
         query_string="""
-        MATCH (n)-[:FROM_TO]->(neighbor)
+        MATCH (n)-[:FROM_TO]-(neighbor)
         WHERE n.`metadata.url`=$url
         AND n.id = $id
         RETURN DISTINCT neighbor

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -401,7 +401,8 @@ class VirtualHavruta:
         url
             of central node
         direction
-            of relationship, one of 'incoming', 'outgoing', 'both_ways'
+           The direction of the edges between nodes, one of 'incoming', 'outgoing', 'both_ways'. In the Sefaria KG, edges point from newer to older references.
+            'incoming' leads to searching for newer references, 'outgoing' for older references, and 'both_ways' for both.
         order
             order of neighbors (=number of hops) to include, between 1 and n
         score_central_node

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -20,6 +20,7 @@ import requests
 from time import sleep
 import neo4j
 
+from VirtualHavruta.util import min_max_scaling
 
 from VirtualHavruta.document import ChunkDocument
 
@@ -1401,7 +1402,7 @@ class VirtualHavruta:
     def get_page_rank_scores(self, documents: list[Document]) -> np.array:
         """Get the PageRank scores for each document.
 
-        Secondary references are assigned a default PageRank score of 1.0 (neutral under multiplication)
+        Perform batch-wise min-max scaling.
 
         Parameters
         ----------
@@ -1411,14 +1412,13 @@ class VirtualHavruta:
         -------
             array of page rank scores
         """
-        page_rank_scores = []
+        page_rank_scores_raw = []
         for doc in documents:
-            if self.is_primary_document(doc):
-                page_rank_score = self.retrieve_pr_score(doc.metadata["URL"])
-            else:
-                page_rank_score = 1.0
-            page_rank_scores.append(page_rank_score)
-        return np.array(page_rank_scores).reshape(-1, 1)
+            page_rank_score = self.retrieve_pr_score(doc.metadata["URL"])
+            page_rank_scores_raw.append(page_rank_score)
+
+        page_rank_scores_scaled = min_max_scaling(page_rank_scores_raw)
+        return np.array(page_rank_scores_scaled).reshape(-1, 1)
 
     def is_primary_document(self, doc: Document) -> bool:
         """Check if a document is a primary document.

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -1278,15 +1278,17 @@ class VirtualHavruta:
         else:
             raise NotImplementedError(f"Distance strategy {self.neo4j_vector._distance_strategy.value} not implemented.")
 
-    def get_reference_class(self, documents: list[Document], query: str) -> np.array:
+    def get_reference_class(self, documents: list[Document], scripture_query: str, enriched_query: str) -> np.array:
         """Get the reference class for each document based on the query.
 
         Parameters
         ----------
         documents
             langchain documents
-        query
+        scripture_query
             query string
+        enriched_query
+            query enriched with additional context
 
         Returns
         -------
@@ -1296,7 +1298,8 @@ class VirtualHavruta:
         total_token_count = 0
         for doc in documents:
             ref_data = doc.page_content + "... --Origin of this " + doc.metadata["source"]
-            ref_class, token_count = self.classification(query, ref_data)
+            query = scripture_query if self.is_primary_document(doc) else enriched_query
+            ref_class, token_count = self.classification(query=query, ref_data=ref_data)
             total_token_count += token_count
             reference_classes.append(ref_class)
         return np.array(reference_classes).reshape(-1, 1), total_token_count

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -441,6 +441,55 @@ class VirtualHavruta:
         record: dict = next(iter(node.values()))
         id_graph_format = record["id"]
         return int(id_graph_format) + 1
+    
+    def get_graph_neighbors_by_url(self, url: str, relationship: str, depth: int) -> list[tuple["Node", float]]:
+        """Given a url, query the graph database for the neighbors of the node with that url.
+
+        Parameters
+        ----------
+        url
+            of central node
+        relationship
+            one of 'incoming', 'outgoing', 'both_ways'
+        depth
+            degree of neighbors to include, between 1 and n
+
+        Returns
+        -------
+            list of (node, similarity) tuples, where similarity decreases with distance to central node in graph
+        """
+        pass
+
+    def query_node_by_url(self, url: str,) -> str|None:
+        """Given a url, query the graph database for the node with that url.
+
+        If more than one node has the same url, return the only one.
+
+        Parameters
+        ----------
+        url
+            of node
+
+        Returns
+        -------
+            unique id of the node
+        """
+        query_parameters = {"url": url}
+        query_string="""
+        MATCH (n)
+        WHERE n.`metadata.url`=$url
+        RETURN n.id
+        LIMIT 1
+        """
+        with GraphDatabase.driver(self.config["database"]["graph_db_url"], auth=(self.config["database"]["db_username"], self.config["database"]["db_password"])) as driver:
+            id, _, _ = driver.execute_query(
+            query_string,
+            parameters_=query_parameters,
+            database_=self.config["database"]["db_name"],)
+        if id:
+            return id[0].data()["n.id"]
+        else:
+            return None
 
     def query_neighbors_of_doc(self, document: Document) -> list[Document]:
         """Given a document, query the graph database for its neighbors.

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -405,10 +405,10 @@ class VirtualHavruta:
         if len(retrieval_res) == 0:
             return retrieval_res
         else:
-            top_1_doc = retrieval_res[0][0]
-            documents = self.query_neighbors_of_doc(top_1_doc)
-            similarity_scores = self.compute_similarity_documents_query(documents, query)
-            return documents, similarity_scores
+            top_1_doc, top_1_similarity = retrieval_res[0]
+            neighbor_docs = self.query_neighbors_of_doc(top_1_doc)
+            neighbor_similarity_scores = self.compute_similarity_documents_query(neighbor_docs, query)
+            return [(top_1_doc, top_1_similarity)]  + [(doc, sim) for doc, sim in zip(neighbor_docs, neighbor_similarity_scores, strict=True)]
 
     def get_document_id_graph_format(self, document: Document) -> str:
         """Given a document from the vectordb, return the document id of the corresponding node in the graph database.
@@ -501,7 +501,7 @@ class VirtualHavruta:
         if self.neo4j_vector._distance_strategy.value.lower() == "cosine":
             similarity = cosine_similarity(query_embedding, document_embeddings)
             relevance_score_function = self.neo4j_vector._select_relevance_score_fn()
-            return relevance_score_function(similarity).squeeze().tolist()
+            return relevance_score_function(similarity).reshape(-1).tolist()
         else:
             raise NotImplementedError(f"Distance strategy {self.neo4j_vector._distance_strategy.value} not implemented.")
 

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -646,7 +646,7 @@ class VirtualHavruta:
             database_=self.config["database"]["kg"]["name"],)
         return [convert_node_to_doc(node) for node in nodes]
 
-    def sort_reference(self, query: str, retrieval_res, msg_id: str = '', filter_mode: str='primary'):
+    def sort_reference(self, query: str, retrieval_res, msg_id: str = ''):
         '''
         Sorts and processes retrieval results for references based on their relevance to a given query, considering both primary and secondary filtering modes.
         
@@ -658,7 +658,6 @@ class VirtualHavruta:
         query (str): The query string against which references are being sorted and classified.
         retrieval_res (iterable): An iterable of tuples containing reference data objects and similarity scores.
         msg_id (str, optional): A message identifier used for logging purposes; defaults to an empty string.
-        filter_mode (str): Determines the mode for filtering references; can be 'primary' or 'secondary'. This affects how relevance scores are calculated.
         
         Returns:
         tuple: A tuple containing sorted source relevance dictionary, source data dictionary, source reference dictionary, and the total token count used during the process.

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -20,122 +20,9 @@ import requests
 from time import sleep
 import neo4j
 
-from VirtualHavruta.util import min_max_scaling
+from VirtualHavruta.util import convert_node_to_doc, convert_vector_db_record_to_doc, \
+    get_id_graph_format, get_node_data, min_max_scaling
 
-from VirtualHavruta.document import ChunkDocument
-
-def dict_to_yaml_str(input_dict: dict, indent: int = 0) -> str:
-    """
-    Convert a dictionary to a YAML-like string without using external libraries.
-
-    Parameters:
-        input_dict: The dictionary to convert.
-        indent: The current indentation level.
-
-    Returns:
-    The YAML-like string representation of the input dictionary.
-    """
-    yaml_str = ""
-    for key, value in input_dict.items():
-        padding = "  " * indent
-        if isinstance(value, dict):
-            yaml_str += f"{padding}{key}:\n{dict_to_yaml_str(value, indent + 1)}"
-        elif isinstance(value, list):
-            yaml_str += f"{padding}{key}:\n"
-            for item in value:
-                yaml_str += f"{padding}- {item}\n"
-        else:
-            yaml_str += f"{padding}{key}: {value}\n"
-    return yaml_str
-
-
-def convert_node_to_doc(node: "Node", base_url: str= "https://www.sefaria.org/") -> Document:
-    """
-    Convert a node from the graph database to a Document object.
-
-    Parameters:
-        node (Node): The node from the graph database.
-
-    Returns:
-        Document: The Document object created from the node.
-    """
-    node_data: dict = get_node_data(node)
-    metadata = {k.replace("metadata.", ""):v for k, v in node_data.items() if k.startswith("metadata.")}
-    metadata['URL'] = metadata['url']
-    del metadata['url']
-    metadata["seq_num"] = get_id_vectordb_format(node_data["id"])
-    new_reference_part = metadata["URL"].replace(base_url, "")
-    new_category = metadata["docCategory"]
-    metadata["source"] = f"Reference: {new_reference_part}. Version Title: -, Document Category: {new_category}, URL: {metadata['URL']}"
-
-    page_content = dict_to_yaml_str(node_data.get("text")) if isinstance(node_data.get("text"), dict) else node_data.get("text", "")
-    return ChunkDocument(
-        page_content=page_content,
-        metadata=metadata
-    )
-
-def convert_vector_db_record_to_doc(record) -> ChunkDocument:
-    assert len(record) == 1
-    record: dict = next(iter(record.values()))
-    page_content = record.pop("text", None)
-    return ChunkDocument(
-        page_content=dict_to_yaml_str(page_content)
-        if isinstance(page_content, dict)
-        else page_content,
-        metadata=record
-    )
-
-def get_node_data(node: "Node") -> dict:
-    """Given a node from the graph database, return the data of the node.
-
-    Parameters
-    ----------
-    node
-        from the graph database
-
-    Returns
-    -------
-        data of the node
-    """
-    try:
-        record = node.data()
-    except AttributeError:
-        record = node._properties
-    else:
-        assert len(record) == 1
-        record: dict = next(iter(record.values()))
-    return record
-
-def get_id_graph_format(document_seq_num: int) -> str:
-    """Given a document seq_num  from the vectordb, return the  id of the corresponding node in the graph database.
-
-    Parameters
-    ----------
-    document_seq_num
-        from the vectordb document
-
-    Returns
-    -------
-        id of the document in the graph database
-    """
-    return str(document_seq_num -1)
-
-def get_id_vectordb_format(node_id: str) -> int:
-    """Given a node id from the graph database, return the corresponding document seq_num in the vectordb.
-
-    Parameters
-    ----------
-    node_id
-        id of node 
-
-    Returns
-    -------
-        seq_num of the document in the vectordb
-
-    Raises
-    ------
-    """
-    return int(node_id) + 1
 
 # Main Virtual Havruta functionalities
 class VirtualHavruta:
@@ -1480,6 +1367,10 @@ class VirtualHavruta:
                 vector_records_batch = self.neo4j_vector.query(query_string, params={"params": query_parameters[i:i+batch_size]})
             except neo4j.exceptions.ServiceUnavailable:
                 self.logger.warning("Neo4j database is unavailable. Retrying.")
+                sleep(1)
+                vector_records_batch = self.neo4j_vector.query(query_string, params={"params": query_parameters[i:i+batch_size]})
+            except BufferError:
+                self.logger.warning("Neo4j encountered an error. Retrying.")
                 sleep(1)
                 vector_records_batch = self.neo4j_vector.query(query_string, params={"params": query_parameters[i:i+batch_size]})
             vector_records += vector_records_batch

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,17 @@
 # DB-related parameters
 database:
-  db_url: bolt://publicip:7687
-  db_username: username
-  db_password: password@dev
-  top_k: 1
-  neo4j_deeplink: "http://neodash.graphapp.io/xxxx"
+  emb_url: bolt://publicip:7687
+  emb_username: user
+  emb_password: password@dev
+  emb_top_k: 1
+  neo4j_deeplink: "http://neodash.graphapp.io/xyz"
+  kg_url: bolt://publicip:7687
+  kg_username: user
+  kg_password: password@dev
+  kg_order: 1
+  kg_direction: both_ways
+  kg_max_nodes: 10
+  kg_name: db_name
 
 # Slack-related parameters
 slack:

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ database:
   emb_url: bolt://publicip:7687
   emb_username: user
   emb_password: password@dev
-  emb_top_k: 1
+  emb_top_k: 15
   neo4j_deeplink: "http://neodash.graphapp.io/xyz"
   kg_url: bolt://publicip:7687
   kg_username: user

--- a/config.yaml
+++ b/config.yaml
@@ -1,17 +1,20 @@
 # DB-related parameters
 database:
-  emb_url: bolt://publicip:7687
-  emb_username: user
-  emb_password: password@dev
-  emb_top_k: 15
-  neo4j_deeplink: "http://neodash.graphapp.io/xyz"
-  kg_url: bolt://publicip:7687
-  kg_username: user
-  kg_password: password@dev
-  kg_order: 1
-  kg_direction: both_ways
-  kg_max_nodes: 10
-  kg_name: db_name
+  embed:
+    url: bolt://publicip:7687
+    username: user
+    password: password@dev
+    top_k: 15
+  kg:
+    url: bolt://publicip_kg:7687
+    username: user
+    password: password@dev
+    order: 1
+    direction: both_ways
+    max_nodes: 10
+    name: db_name
+    neo4j_deeplink: http://neodash.graphapp.io/xyz
+
 
 # Slack-related parameters
 slack:

--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,8 @@ database:
     password: password@dev
     order: 1
     direction: both_ways
-    k_seeds: 5
-    max_depth: 2
+    k_seeds: 5 # number of starting seeds for search, chosen by semantic similarity
+    max_depth: 2 # maximum number of retrieved chunks at the end of the kg search step. This also limits the maximum path length between any seed node and any node corresponding to a retrieved chunk.
     name: db_name
     neo4j_deeplink: http://neodash.graphapp.io/xyz
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,8 @@ database:
     password: password@dev
     order: 1
     direction: both_ways
-    max_nodes: 10
+    k_seeds: 5
+    max_depth: 2
     name: db_name
     neo4j_deeplink: http://neodash.graphapp.io/xyz
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,8 @@ database:
     username: user
     password: password@dev
     order: 1
-    direction: both_ways
+    direction: both_ways # The direction of the edges between nodes, one of 'incoming', 'outgoing', 'both_ways'. 
+    # In the Sefaria KG, edges point from newer to older references. 'incoming' leads to searching for newer references, 'outgoing' for older references, and 'both_ways' for both.
     k_seeds: 5 # number of starting seeds for search, chosen by semantic similarity
     max_depth: 2 # maximum number of retrieved chunks at the end of the kg search step. This also limits the maximum path length between any seed node and any node corresponding to a retrieved chunk.
     name: db_name


### PR DESCRIPTION
Found a way to keep my commit history without duplicating existing commits from main.
points still to review where:

semantic similarity: compute it based upon enriched_query
reference_class: use scripture_query for primary, enriched_query for secondary sources
pagerank: not for secondary (I still apply it to secondary sources in the kg search setting, if they are mixed with primary sources)
sort_reference: use filter_mode parameter in score calculations