### PR TITLE
fix(query): improve performance by restricting MATCH to 'Chunk' or 'Records' labels

### DIFF
--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -491,7 +491,7 @@ class VirtualHavruta:
         for i in range(1, depth + 1):
             source_filter = f'AND {"NOT" if filter_mode_nodes == "secondary" else ""} neighbor.primaryDocCategory IN $primaryDocCategories' if filter_mode_nodes else ''
             query = f"""
-            MATCH (start {{url: $url}})
+            MATCH (start:Records {{url: $url}})
             WITH start
             MATCH (start){start_node_operator}[:FROM_TO*{i}]{related_node_operator}(neighbor)
             WHERE neighbor <> start
@@ -506,36 +506,6 @@ class VirtualHavruta:
             nodes.extend(neighbor_nodes)
         self.logger.info(f"MsgID={msg_id}. [GRAGH NEIGHBOR RETRIEVAL] Retrieved graph neighbors: {nodes}.")
         return nodes
-    
-    def query_kg_node_by_url(self, url: str) -> str|None:
-        """Given a url, query the graph database for the node with that url.
-
-        If more than one node has the same url, return only one.
-
-        Parameters
-        ----------
-        url
-            of node
-
-        Returns
-        -------
-            node
-        """        
-        query_parameters = {"url": url}
-        query_string="""
-        MATCH (n:Records)
-        WHERE n.url=$url
-        RETURN n
-        """
-        with neo4j.GraphDatabase.driver(self.config["database"]["kg"]["url"], auth=(self.config["database"]["kg"]["username"], self.config["database"]["kg"]["password"])) as driver:
-            nodes, _, _ = driver.execute_query(
-            query_string,
-            parameters_=query_parameters,
-            database_=self.config["database"]["kg"] ["name"],)
-        if nodes:
-            return nodes
-        else:
-            return None
 
     def query_graph_db_by_url(self, urls: list[str]) -> list[Document]:
         """Given a list of urls, query the graph database for the nodes with those urls.

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -1493,7 +1493,7 @@ class VirtualHavruta:
         query_parameters = {"url": chunk.metadata["url"], "versionTitle": chunk.metadata["versionTitle"]}
         self.logger.info(f"MsgID={msg_id}. [CHUNK2NODE] Using the following chunk to find a corresponding node: {query_parameters}")
         query_string="""
-        MATCH (n)
+        MATCH (n:Records)
         WHERE n.url=$url
         AND n.versionTitle=$versionTitle
         RETURN n

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -1459,7 +1459,7 @@ class VirtualHavruta:
         self.logger.info(f"MsgID={msg_id}. [NODE2CHUNK] Using the following nodes to find corresponding chunks: {query_parameters}")
         query_string = """
         UNWIND $params AS param
-        MATCH (n)
+        MATCH (n:Chunk)
         WHERE n.versionTitle = param.versionTitle AND n.url = param.url
         RETURN n
         """

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -507,7 +507,7 @@ class VirtualHavruta:
         self.logger.info(f"MsgID={msg_id}. [GRAGH NEIGHBOR RETRIEVAL] Retrieved graph neighbors: {nodes}.")
         return nodes
     
-    def query_node_by_url(self, url: str,) -> str|None:
+    def query_kg_node_by_url(self, url: str) -> str|None:
         """Given a url, query the graph database for the node with that url.
 
         If more than one node has the same url, return only one.
@@ -519,22 +519,21 @@ class VirtualHavruta:
 
         Returns
         -------
-            unique id of the node
-        """
+            node
+        """        
         query_parameters = {"url": url}
         query_string="""
-        MATCH (n)
-        WHERE n.`metadata.url`=$url
-        RETURN n.id
-        LIMIT 1
+        MATCH (n:Records)
+        WHERE n.url=$url
+        RETURN n
         """
         with neo4j.GraphDatabase.driver(self.config["database"]["kg"]["url"], auth=(self.config["database"]["kg"]["username"], self.config["database"]["kg"]["password"])) as driver:
-            id, _, _ = driver.execute_query(
+            nodes, _, _ = driver.execute_query(
             query_string,
             parameters_=query_parameters,
             database_=self.config["database"]["kg"] ["name"],)
-        if id:
-            return id[0].data()["n.id"]
+        if nodes:
+            return nodes
         else:
             return None
 

--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -557,7 +557,7 @@ class VirtualHavruta:
         """
         query_parameters = {"urls": urls}
         query_string="""
-        MATCH (n)
+        MATCH (n:Records)
         WHERE any(substring IN $urls WHERE n.url CONTAINS substring)
         RETURN n
         """


### PR DESCRIPTION
Changed `MATCH (n)` to `MATCH (n:Chunk)` on line 1462 so neo4j query planner uses the existing index.