### PR TITLE
chore(dependencies): add pytest to requirements.txt for testing frame…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ typing-inspect==0.9.0
 tzdata==2024.1
 urllib3==2.2.1
 yarl==1.9.4
+pytest==8.3.3


### PR DESCRIPTION
Added `pytest` version 8.3.3 to the `requirements.txt` file to establish a standardized testing framework for the project. This change ensures that all contributors use `pytest` as the primary testing tool, simplifying test execution and maintaining consistency across different development environments.
