### PR TITLE
fix: add database parameter to Neo4jVector.from_existing_index

### DIFF
--- a/VirtualHavruta/vh.py
+++ b/VirtualHavruta/vh.py
@@ -71,13 +71,14 @@ class VirtualHavruta:
         self.config_emb_db = self.config['database']['embed']
         self.config_kg_db = self.config['database']['kg']
         
-        # Initialize Neo4j vector index 
+        # Initialize Neo4j vector index
         self.neo4j_vector = Neo4jVector.from_existing_index(
             OpenAIEmbeddings(model=self.model_api['embedding_model']),
-            index_name="index",
+            index_name=self.config_emb_db.get('index_name', 'index'),
             url=self.config_emb_db['url'],
             username=self.config_emb_db['username'],
             password=self.config_emb_db['password'],
+            database=self.config_emb_db.get('database', 'neo4j'),
         )
         self.top_k = self.config_emb_db['top_k']
 


### PR DESCRIPTION
from_existing_index() ignores database parameter and always connects to default "neo4j" database. This causes "vector index not found" error when using non-default database names.

Also make index_name configurable instead of hardcoded.

Ref: https://github.com/langchain-ai/langchain-neo4j/issues/82